### PR TITLE
Comprobar el coverage solo en las PR.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
         run: poetry run pytest --cov-report xml:coverage.xml
 
       - name: Get Cover
+        if: github.event_name == 'pull_request'
         uses: orgoro/coverage@v3.1
         with:
           coverageFile: coverage.xml


### PR DESCRIPTION
El Github Action para comprobar el coverage solo funciona con las PRs.